### PR TITLE
Add planning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,11 @@ Apple Silicon (especially the Neural Engine) enables fast, private voice agents 
 ---
 
 *This README summarizes technical guidance from a ChatGPT session on building local AI voice agents for macOS*
+
+## Planning Documents
+
+For an overview of the proposed architecture and development tasks, see the [docs](docs/) directory:
+
+- [docs/architecture.md](docs/architecture.md) &ndash; component breakdown and real-time audio pipeline
+- [docs/todo.md](docs/todo.md) &ndash; list of upcoming work items
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,48 @@
+# Architecture Overview
+
+This document outlines the planned architecture for the real-time voice chat application.
+
+## Goals
+
+- Modern UI for voice conversations on macOS
+- Low-latency interaction with streaming STT and TTS
+- Graceful handling of user interruptions
+- Pluggable AI agent interface for conversation logic and UI updates
+
+## Components
+
+1. **UI Layer**
+   - Built with a cross-platform toolkit (Electron, Tauri or SwiftUI)
+   - Displays conversation history and agent state
+   - Streams microphone audio to the STT engine
+   - Receives updates from the agent to modify the UI in real time
+
+2. **Audio Pipeline**
+   - Microphone input is fed to the STT engine which emits partial and final transcripts
+   - Final transcript triggers the agent
+   - Agent response is converted to speech by the TTS engine and streamed back to the user
+
+3. **Agent Interface**
+   - Abstract interface that receives text and returns text plus optional actions
+   - Initial implementation will be a simple LLM chat agent
+   - Designed so that more advanced agents can be plugged in without major changes
+
+4. **Interruption Detection**
+   - Voice activity detection (VAD) monitors microphone input
+   - When the user speaks while the agent is talking, TTS playback stops and the transcript resumes
+
+5. **Real-Time Loop**
+   - Asynchronous event loop connecting STT, Agent and TTS via queues
+   - Allows overlapping operations for minimal latency
+
+## Proposed Directory Structure
+
+```
+docs/              - documentation
+src/
+  ui/              - UI components
+  stt/             - speech-to-text utilities
+  tts/             - text-to-speech utilities
+  agent/           - pluggable agent implementations
+  core/            - event loop and common utilities
+```

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,0 +1,14 @@
+# TODO
+
+A list of initial tasks to move the project forward.
+
+1. Select the UI framework (Electron, Tauri or SwiftUI) and create a basic window layout.
+2. Implement microphone capture and streaming to the STT engine.
+3. Integrate a streaming STT backend (e.g. whisper.cpp or mlx-whisper).
+4. Build a simple LLM chat agent that conforms to the agent interface.
+5. Implement a TTS backend capable of streaming audio playback.
+6. Create the asynchronous event loop connecting STT, Agent and TTS modules.
+7. Add interruption detection so user speech can cut off TTS playback.
+8. Define a plugin mechanism to swap out the agent with more advanced versions.
+9. Document configuration options and provide example scripts.
+10. Write tests for individual components where possible.


### PR DESCRIPTION
## Summary
- add project planning docs
- document architecture and TODO tasks
- mention docs folder in README

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_684971a136548329a9ee337a589401e3