### PR TITLE
Add backend scaffolding and runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ PCM audio streamed from the web UI and yields transcription results as they are
 produced. Install `vosk` then run:
 
 ```python
-from src.stt import VoskStream
+from src.backend.stt import VoskStream
 
 stream = VoskStream("/path/to/vosk-model")
 
@@ -156,6 +156,19 @@ async for t in stream.stream():
 ```
 
 This will print partial and final transcripts from the streamed audio.
+
+---
+## Running the Backend
+
+A small runner script wires the pieces together using an echo agent and a console
+TTS implementation:
+
+```bash
+python -m src.backend.core.runner /path/to/vosk-model --turns 1
+```
+
+The script processes microphone audio via `VoskStream` and prints the agent reply
+to stdout.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,7 @@ This document outlines the planned architecture for the real-time voice chat app
 5. **Real-Time Loop**
    - Asynchronous event loop connecting STT, Agent and TTS via queues
    - Allows overlapping operations for minimal latency
+   - Implemented by `ChatBackend` in `src/backend/core/backend.py`
 
 ## Proposed Directory Structure
 
@@ -49,3 +50,6 @@ src/
     agent/         - pluggable agent implementations
     core/          - event loop and common utilities
 ```
+
+A simple CLI runner located at `src/backend/core/runner.py` wires the default
+components together for testing.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -22,3 +22,4 @@ A list of initial tasks to move the project forward.
 1. Integrate the Vosk backend for real-time transcription.
 1. Add README files for the source modules.
 1. Implemented a microphone toggle in the React UI to start/stop audio capture.
+1. Created backend scaffolding with an event loop and CLI runner script.

--- a/src/backend/agent/base.py
+++ b/src/backend/agent/base.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import abc
+
+
+class Agent(abc.ABC):
+    """Abstract chat agent."""
+
+    @abc.abstractmethod
+    async def process(self, text: str) -> str:
+        """Return a response for the given input text."""
+        raise NotImplementedError

--- a/src/backend/agent/simple.py
+++ b/src/backend/agent/simple.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from .base import Agent
+
+
+class EchoAgent(Agent):
+    """A trivial agent that echoes the input text."""
+
+    async def process(self, text: str) -> str:
+        return text

--- a/src/backend/core/backend.py
+++ b/src/backend/core/backend.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from ..stt import Transcript
+from ..agent.base import Agent
+from ..tts.base import TTS
+
+
+class ChatBackend:
+    """Wire STT, Agent and TTS together."""
+
+    def __init__(self, stt, agent: Agent, tts: TTS) -> None:
+        self.stt = stt
+        self.agent = agent
+        self.tts = tts
+
+    async def run(self, turns: int = -1) -> None:
+        """Run the main loop.
+
+        Parameters
+        ----------
+        turns: int
+            Stop after this many final transcripts if > 0.
+        """
+        final_count = 0
+        async for transcript in self.stt.stream():
+            if transcript.is_final:
+                reply = await self.agent.process(transcript.text)
+                await self.tts.speak(reply)
+                final_count += 1
+                if turns > 0 and final_count >= turns:
+                    break

--- a/src/backend/core/runner.py
+++ b/src/backend/core/runner.py
@@ -1,0 +1,27 @@
+"""Command line entry point for the backend."""
+
+import argparse
+import asyncio
+
+from ..stt import VoskStream
+from ..agent.simple import EchoAgent
+from ..tts.simple import ConsoleTTS
+from .backend import ChatBackend
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the chat backend")
+    parser.add_argument("model", help="Path to Vosk model")
+    parser.add_argument("--turns", type=int, default=-1, help="Number of turns to process")
+    args = parser.parse_args()
+
+    stt = VoskStream(args.model)
+    agent = EchoAgent()
+    tts = ConsoleTTS()
+
+    backend = ChatBackend(stt, agent, tts)
+    asyncio.run(backend.run(turns=args.turns))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backend/tts/base.py
+++ b/src/backend/tts/base.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import abc
+
+
+class TTS(abc.ABC):
+    """Abstract text-to-speech interface."""
+
+    @abc.abstractmethod
+    async def speak(self, text: str) -> None:
+        """Speak the given text."""
+        raise NotImplementedError

--- a/src/backend/tts/simple.py
+++ b/src/backend/tts/simple.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from .base import TTS
+
+
+class ConsoleTTS(TTS):
+    """TTS implementation that just prints to stdout."""
+
+    async def speak(self, text: str) -> None:
+        print(text)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,40 @@
+import asyncio
+import pathlib
+import sys
+from unittest import mock
+
+# Allow importing the src package
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from src.backend.core.backend import ChatBackend
+from src.backend.stt import Transcript
+from src.backend.agent.base import Agent
+from src.backend.tts.base import TTS
+
+
+class DummyAgent(Agent):
+    async def process(self, text: str) -> str:
+        return text.upper()
+
+
+class DummyTTS(TTS):
+    def __init__(self) -> None:
+        self.spoken = []
+
+    async def speak(self, text: str) -> None:
+        self.spoken.append(text)
+
+
+def test_backend_processes_final_transcripts():
+    async def gen():
+        yield Transcript(text="hello", is_final=True)
+        yield Transcript(text="world", is_final=True)
+
+    stt = mock.Mock()
+    stt.stream.return_value = gen()
+
+    backend = ChatBackend(stt, DummyAgent(), DummyTTS())
+    tts = backend.tts
+    asyncio.run(backend.run(turns=2))
+
+    assert tts.spoken == ["HELLO", "WORLD"]

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -6,12 +6,12 @@ from unittest import mock
 # Allow importing the src package
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
-from src.stt import VoskStream, Transcript
+from src.backend.stt import VoskStream, Transcript
 
 
 def test_vosk_stream_yields_partial_and_final():
     # Mock vosk classes
-    with mock.patch("src.stt.streaming.vosk") as m_vosk:
+    with mock.patch("src.backend.stt.streaming.vosk") as m_vosk:
         m_vosk.Model.return_value = mock.Mock()
         rec_instance = mock.Mock()
         m_vosk.KaldiRecognizer.return_value = rec_instance
@@ -35,7 +35,4 @@ def test_vosk_stream_yields_partial_and_final():
             assert final == Transcript(text="hello", is_final=True)
 
         asyncio.run(run_test())
-
-
-
 


### PR DESCRIPTION
## Summary
- scaffold agent and TTS base classes with simple implementations
- implement `ChatBackend` event loop and CLI runner
- add test coverage for backend controller
- update README with runner instructions
- document backend in architecture and todo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849960a469c83299313764f9e18821f