### PR TITLE
Fix websocket server CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ to stdout.
 
 ### Running the WebSocket server
 
-To stream audio from the React UI, start the WebSocket server:
+To stream audio from the React UI, start the WebSocket server. It prints the
+address it is listening on and runs until interrupted. Use `--host` and
+`--port` to change the bind address:
 
 ```bash
 python -m src.backend.core.websocket_server vosk-model

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -27,3 +27,5 @@ A list of initial tasks to move the project forward.
 1. Added dependency management with `requirements.txt` and backend setup instructions.
 1. Documented how to download and use a Vosk model for the backend.
 1. Added WebSocket server for streaming audio from the UI.
+1. Fixed WebSocket server CLI entrypoint to start the server and display a
+   startup message.

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -37,7 +37,9 @@ Each final transcript will be echoed back to you as text output. The `--turns` a
 
 ### WebSocket server
 
-The React UI streams audio over a WebSocket connection. Start the server like so:
+The React UI streams audio over a WebSocket connection. Start the server and it
+will print the address it's listening on. Use `--host` and `--port` to change the
+default of `localhost:8000`:
 
 ```bash
 python -m src.backend.core.websocket_server vosk-model

--- a/tests/test_ws_server.py
+++ b/tests/test_ws_server.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
+from src.backend.core import websocket_server
 from src.backend.core.websocket_server import AudioWebSocketServer
 from src.backend.stt import Transcript
 
@@ -65,3 +66,13 @@ def test_send_transcripts_sends_messages():
             json.dumps({"text": "hi", "final": False}),
             json.dumps({"text": "bye", "final": True}),
         ]
+
+
+def test_main_starts_server():
+    with mock.patch("src.backend.core.websocket_server.AudioWebSocketServer") as cls, \
+         mock.patch("asyncio.run") as run:
+        inst = cls.return_value
+        websocket_server.main(["model", "--host", "0.0.0.0", "--port", "1234"])
+
+        cls.assert_called_with("model", host="0.0.0.0", port=1234)
+        run.assert_called_once_with(inst.run())


### PR DESCRIPTION
## Summary
- add command line interface for websocket server
- document the host/port options and startup message
- note the change in project todo
- test the websocket server CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849bea28fe88329b958808ceac09326