### PR TITLE
Fix MediaRecorder streaming

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -30,3 +30,4 @@ A list of initial tasks to move the project forward.
 1. Fixed WebSocket server CLI entrypoint to start the server and display a
    startup message.
 1. Added audio byte counters in the UI and periodic byte logging on the backend.
+1. Fixed zero-byte streaming bug by starting MediaRecorder with a timeslice.

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -54,7 +54,8 @@ export default function App() {
             console.error('Failed to parse message', err);
           }
         };
-        mediaRecorder.start();
+        // Pass a timeslice so dataavailable fires periodically
+        mediaRecorder.start(250);
         console.log('Microphone capture started');
         setListening(true);
       } catch (err) {


### PR DESCRIPTION
## Summary
- fix audio streaming by starting the MediaRecorder with a timeslice
- document the fix in the todo list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac1a06bb8832980204384a9a8b158