### PR TITLE
Add transcript logging and improved byte stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ to stdout.
 
 To stream audio from the React UI, start the WebSocket server. It prints the
 address it is listening on and runs until interrupted. Use `--host` and
-`--port` to change the bind address:
+`--port` to change the bind address. Final transcripts are written to
+`transcript.log` by default. Use `--transcript-log` to change the file path:
 
 ```bash
 python -m src.backend.core.websocket_server vosk-model

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,6 +21,7 @@ This document outlines the planned architecture for the real-time voice chat app
 
 2. **Audio Pipeline**
    - Audio from the UI is fed to the STT engine which emits partial and final transcripts
+   - Final transcripts are appended to `transcript.log` for debugging
    - Final transcript triggers the agent
    - Agent response is converted to speech by the TTS engine and streamed back to the user
    - Current implementation uses the Vosk backend for real-time STT streaming

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -31,3 +31,4 @@ A list of initial tasks to move the project forward.
    startup message.
 1. Added audio byte counters in the UI and periodic byte logging on the backend.
 1. Fixed zero-byte streaming bug by starting MediaRecorder with a timeslice.
+1. Added transcript logging and improved byte logging to avoid duplicates.

--- a/tests/test_ws_server.py
+++ b/tests/test_ws_server.py
@@ -4,6 +4,8 @@ import pathlib
 import sys
 from unittest import mock
 
+import pytest
+
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 from src.backend.core import websocket_server
@@ -34,13 +36,17 @@ def test_handler_feeds_audio():
     async def dummy_send(self, ws):
         return None
 
-    with mock.patch("src.backend.core.websocket_server.websockets", mock.Mock()), \
-         mock.patch("src.backend.core.websocket_server.VoskStream") as m_vosk, \
-         mock.patch.object(AudioWebSocketServer, "_send_transcripts", dummy_send):
+    with mock.patch(
+        "src.backend.core.websocket_server.websockets", mock.Mock()
+    ), mock.patch(
+        "src.backend.core.websocket_server.VoskStream"
+    ) as m_vosk, mock.patch.object(
+        AudioWebSocketServer, "_send_transcripts", dummy_send
+    ):
         stt_instance = mock.Mock()
         m_vosk.return_value = stt_instance
 
-        server = AudioWebSocketServer("model")
+        server = AudioWebSocketServer("model", transcript_log=None)
         asyncio.run(server._handler(dummy_ws))
 
         assert stt_instance.feed_audio.call_count == 2
@@ -54,13 +60,14 @@ def test_send_transcripts_sends_messages():
 
     dummy_ws = DummyWebSocket()
 
-    with mock.patch("src.backend.core.websocket_server.websockets", mock.Mock()), \
-         mock.patch("src.backend.core.websocket_server.VoskStream") as m_vosk:
+    with mock.patch(
+        "src.backend.core.websocket_server.websockets", mock.Mock()
+    ), mock.patch("src.backend.core.websocket_server.VoskStream") as m_vosk:
         stt_instance = mock.Mock()
         stt_instance.stream.return_value = gen()
         m_vosk.return_value = stt_instance
 
-        server = AudioWebSocketServer("model")
+        server = AudioWebSocketServer("model", transcript_log=None)
         asyncio.run(server._send_transcripts(dummy_ws))
 
         assert dummy_ws.sent == [
@@ -69,11 +76,63 @@ def test_send_transcripts_sends_messages():
         ]
 
 
+def test_send_transcripts_logs_transcripts(tmp_path):
+    async def gen():
+        yield Transcript(text="hello", is_final=True)
+
+    dummy_ws = DummyWebSocket()
+
+    with mock.patch(
+        "src.backend.core.websocket_server.websockets", mock.Mock()
+    ), mock.patch("src.backend.core.websocket_server.VoskStream") as m_vosk:
+        stt_instance = mock.Mock()
+        stt_instance.stream.return_value = gen()
+        m_vosk.return_value = stt_instance
+
+        log_file = tmp_path / "t.log"
+        server = AudioWebSocketServer("model", transcript_log=str(log_file))
+        asyncio.run(server._send_transcripts(dummy_ws))
+
+        assert log_file.read_text() == "hello\n"
+
+
 def test_main_starts_server():
-    with mock.patch("src.backend.core.websocket_server.AudioWebSocketServer") as cls, \
-         mock.patch("asyncio.run") as run:
+    with mock.patch(
+        "src.backend.core.websocket_server.AudioWebSocketServer"
+    ) as cls, mock.patch("asyncio.run") as run:
         inst = cls.return_value
         websocket_server.main(["model", "--host", "0.0.0.0", "--port", "1234"])
 
-        cls.assert_called_with("model", host="0.0.0.0", port=1234)
+        cls.assert_called_with(
+            "model", host="0.0.0.0", port=1234, transcript_log="transcript.log"
+        )
         run.assert_called_once_with(inst.run())
+
+
+def test_log_bytes_only_when_changed():
+    with mock.patch(
+        "src.backend.core.websocket_server.websockets", mock.Mock()
+    ), mock.patch("src.backend.core.websocket_server.VoskStream"):
+        server = AudioWebSocketServer("model", transcript_log=None)
+
+        async def fake_sleep(_: float):
+            raise asyncio.CancelledError
+
+        with mock.patch("asyncio.sleep", fake_sleep), mock.patch(
+            "builtins.print"
+        ) as m_print:
+            with pytest.raises(asyncio.CancelledError):
+                asyncio.run(server._log_bytes())
+            m_print.assert_not_called()
+
+        server.bytes_received = 1
+
+        async def fake_sleep2(_: float):
+            pass
+
+        with mock.patch("asyncio.sleep", fake_sleep2), mock.patch(
+            "builtins.print", side_effect=asyncio.CancelledError
+        ) as m_print:
+            with pytest.raises(asyncio.CancelledError):
+                asyncio.run(server._log_bytes())
+            m_print.assert_called_once()


### PR DESCRIPTION
## Summary
- log final transcripts to a file in `AudioWebSocketServer`
- only print byte counts when they change
- expose `--transcript-log` CLI option and document it
- update architecture docs and todo list
- cover new behaviour in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac425cdf48329a8a90729d3793ce1