### PR TITLE
Integrate echo agent with websocket server

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ address it is listening on and runs until interrupted. Use `--host` and
 python -m src.backend.core.websocket_server vosk-model
 ```
 
+The server now also feeds final transcripts to the built-in echo agent and
+`ConsoleTTS`. The echoed response is printed and sent back over the WebSocket.
+
 ---
 ## Final Thoughts
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,8 @@ This document outlines the planned architecture for the real-time voice chat app
    - Final transcript triggers the agent
    - Agent response is converted to speech by the TTS engine and streamed back to the user
    - Current implementation uses the Vosk backend for real-time STT streaming
+   - The WebSocket server echoes final transcripts via an `EchoAgent` and
+     `ConsoleTTS`
 
 3. **Agent Interface**
    - Abstract interface that receives text and returns text plus optional actions

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -33,3 +33,4 @@ A list of initial tasks to move the project forward.
 1. Fixed zero-byte streaming bug by starting MediaRecorder with a timeslice.
 1. Added transcript logging and improved byte logging to avoid duplicates.
 1. Fixed incorrect audio encoding by streaming raw 16 kHz PCM via an AudioWorklet.
+1. Hooked up the WebSocket server to the echo agent and console TTS.


### PR DESCRIPTION
## Summary
- wire the websocket server to the EchoAgent and ConsoleTTS
- echo transcripts back over the websocket and print them
- document the new behavior in the README and architecture docs
- record completion in `docs/todo.md`
- update websocket server tests for the new reply handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad6735d2083299137faf05cd6d128