### PR TITLE
Add macOS say TTS backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Python artifacts
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This project aims to provide a foundation for building a fully on-device AI voic
 ## Features
 
 - **Speech-to-Text (STT):** High-accuracy, low-latency transcription using local models
-- **Text-to-Speech (TTS):** Backend-generated audio is streamed to the UI for playback
+- **Text-to-Speech (TTS):** Speech is generated with the macOS `say` command (if available)
+  and streamed to the UI for playback
 - **Voice Chat Loop:** Real-time, conversational back-and-forth between user and agent
 - **Optimized for Apple Silicon:** Utilizes Metal, Core ML, and Neural Engine
 - **Built-in streaming STT:** Real-time microphone transcription powered by Vosk
@@ -197,15 +198,18 @@ to stdout.
 
 To stream audio from the React UI, start the WebSocket server. It prints the
 address it is listening on and runs until interrupted. Use `--host` and
-`--port` to change the bind address. Final transcripts are written to
-`transcript.log` by default. Use `--transcript-log` to change the file path:
+`--port` to change the bind address. Conversation transcripts are written to
+`transcript.log` by default. Use `--transcript-log` to change the file path.
+Each line in the log is timestamped with millisecond precision and prefixed with
+`<` or `>` to indicate STT input or TTS output:
 
 ```bash
 python -m src.backend.core.websocket_server vosk-model
 ```
 
-The server now also feeds final transcripts to the built-in echo agent and
-`ConsoleTTS`. The echoed response is printed and sent back over the WebSocket.
+The server now also feeds final transcripts to the built-in echo agent. Speech
+is produced using `say` on macOS (falling back to a short beep if unavailable),
+streamed back over the WebSocket and recorded in `transcript.log`.
 
 ---
 ## Final Thoughts

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,14 +20,15 @@ This document outlines the planned architecture for the real-time voice chat app
    - Receives updates from the agent to modify the UI in real time
 
 2. **Audio Pipeline**
-   - Audio from the UI is fed to the STT engine which emits partial and final transcripts
-   - Final transcripts are appended to `transcript.log` for debugging
-   - Final transcript triggers the agent
+  - Audio from the UI is fed to the STT engine which emits partial and final transcripts
+  - Final transcripts and agent replies are appended to `transcript.log`
+    with millisecond timestamps and `<`/`>` prefixes
+  - A final transcript triggers the agent
   - Agent response is converted to speech by the TTS engine and streamed back to the user
   - The backend streams TTS audio to the UI which plays it via the Web Audio API
   - Current implementation uses the Vosk backend for real-time STT streaming
   - The WebSocket server echoes final transcripts via an `EchoAgent` and
-    `ConsoleTTS`
+    `MacSayTTS` (falls back to `ConsoleTTS` if `say` is unavailable)
 
 3. **Agent Interface**
    - Abstract interface that receives text and returns text plus optional actions

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -7,7 +7,6 @@ A list of initial tasks to move the project forward.
 1. ~~Implement microphone capture and streaming to the STT engine.~~
 1. ~~Integrate a streaming STT backend (e.g. whisper.cpp or mlx-whisper).~~
 1. Build a simple LLM chat agent that conforms to the agent interface.
-1. Implement a TTS backend capable of streaming audio playback.
 1. Create the asynchronous event loop connecting STT, Agent and TTS modules.
 1. Add interruption detection so user speech can cut off TTS playback.
 1. Define a plugin mechanism to swap out the agent with more advanced versions.
@@ -36,3 +35,5 @@ A list of initial tasks to move the project forward.
 1. Hooked up the WebSocket server to the echo agent and console TTS.
 1. Added browser speech synthesis and fixed duplicate transcripts in the UI.
 1. Switched to backend TTS streaming audio to the UI for playback.
+1. Added timestamped transcript logging for STT and TTS without console output.
+1. Implemented a macOS `say` TTS backend for streaming speech audio.

--- a/src/backend/tts/macsay.py
+++ b/src/backend/tts/macsay.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import shutil
+import tempfile
+from pathlib import Path
+
+from .base import TTS
+
+
+class MacSayTTS(TTS):
+    """TTS using the macOS ``say`` command."""
+
+    def __init__(self, voice: str = "Samantha") -> None:
+        if shutil.which("say") is None:
+            raise RuntimeError("'say' command not found")
+        self.voice = voice
+
+    async def speak(self, text: str) -> bytes:
+        def _run() -> bytes:
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+                path = Path(tmp.name)
+            cmd = [
+                "say",
+                "-v",
+                self.voice,
+                text,
+                "-o",
+                str(path),
+                "--data-format=LEI16@16000",
+            ]
+            subprocess.run(cmd, check=True)
+            data = path.read_bytes()
+            path.unlink(missing_ok=True)
+            return data
+
+        return await asyncio.to_thread(_run)

--- a/src/backend/tts/simple.py
+++ b/src/backend/tts/simple.py
@@ -9,10 +9,9 @@ from .base import TTS
 
 
 class ConsoleTTS(TTS):
-    """TTS implementation that prints the text and returns a short beep."""
+    """TTS implementation that returns a short beep for any text."""
 
     async def speak(self, text: str) -> bytes:
-        print(text)
 
         sr = 16000
         duration = 0.3


### PR DESCRIPTION
## Summary
- add `MacSayTTS` implementation using the macOS `say` command
- prefer `MacSayTTS` in `AudioWebSocketServer`
- update README and architecture docs for new TTS backend
- document completion in todo list
- ignore Python bytecode
- adjust tests for new default TTS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af8775d7c8329a3a059f5ca03de90