### PR TITLE
Add Orpheus StyleTTS backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ This project aims to provide a foundation for building a fully on-device AI voic
 ## Features
 
 - **Speech-to-Text (STT):** High-accuracy, low-latency transcription using local models
-- **Text-to-Speech (TTS):** Speech is generated with the macOS `say` command (if available)
-  and streamed to the UI for playback
+- **Text-to-Speech (TTS):** Speech is generated with **Orpheus 3B / StyleTTS 2**
+  (falling back to the macOS `say` command if unavailable) and streamed to the UI
+  for playback
 - **Voice Chat Loop:** Real-time, conversational back-and-forth between user and agent
 - **Optimized for Apple Silicon:** Utilizes Metal, Core ML, and Neural Engine
 - **Built-in streaming STT:** Real-time microphone transcription powered by Vosk
@@ -45,8 +46,7 @@ This project aims to provide a foundation for building a fully on-device AI voic
 | ---------------- | -------------------------------------------------- | ------------------------------------------ |
 | **Piper (MIT)**  | `brew install portaudio`<br>`git clone https://github.com/rhasspy/piper && make` | Fast, many voices, 24kHz, <1GB             |
 | **Kokoro-82 M**  | `pip install kokoro`                               | Very fast, 82M params, natural sound       |
-| **Orpheus-TTS**  | `pip install orpheus-speech`                       | 150M-3B params, zero-shot cloning, fp8     |
-| **StyleTTS 2**   | `git clone https://github.com/yl4579/StyleTTS2`    | Diffusion-based, near-human quality        |
+| **Orpheus 3B / StyleTTS 2** | `pip install orpheus-speech`<br>`git lfs clone https://huggingface.co/orpheus-speech/orpheus-3b-styletts2` | Diffusion-based, near-human quality |
 | **Mimic 3**      | `pip install mimic3-tts`                           | <1GB RAM, privacy-first, multi-language    |
 | **AVSpeechSynthesizer** | Native API                                  | Built-in voices, offline once downloaded   |
 
@@ -184,6 +184,19 @@ curl -L -o model.zip https://alphacephei.com/vosk/models/vosk-model-small-en-us-
 unzip model.zip && mv vosk-model-small-en-us-0.15 vosk-model
 ```
 
+### Installing Orpheus 3B / StyleTTS 2
+
+Install the TTS package and download the model weights:
+
+```bash
+pip install orpheus-speech
+git lfs install
+git lfs clone https://huggingface.co/orpheus-speech/orpheus-3b-styletts2
+```
+
+Set the `ORPHEUS_MODEL` environment variable to the path of the cloned
+repository so the backend can find it.
+
 A small runner script wires the pieces together using an echo agent and a console
 TTS implementation:
 
@@ -208,8 +221,9 @@ python -m src.backend.core.websocket_server vosk-model
 ```
 
 The server now also feeds final transcripts to the built-in echo agent. Speech
-is produced using `say` on macOS (falling back to a short beep if unavailable),
-streamed back over the WebSocket and recorded in `transcript.log`.
+is produced using **Orpheus 3B / StyleTTS 2** (falling back to `say` on macOS or
+a short beep if unavailable), streamed back over the WebSocket and recorded in
+`transcript.log`.
 
 ---
 ## Final Thoughts

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ This document outlines the planned architecture for the real-time voice chat app
   - The backend streams TTS audio to the UI which plays it via the Web Audio API
   - Current implementation uses the Vosk backend for real-time STT streaming
   - The WebSocket server echoes final transcripts via an `EchoAgent` and
-    `MacSayTTS` (falls back to `ConsoleTTS` if `say` is unavailable)
+    `OrpheusStyleTTS` (falls back to `MacSayTTS` or `ConsoleTTS` if unavailable)
 
 3. **Agent Interface**
    - Abstract interface that receives text and returns text plus optional actions

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -37,3 +37,4 @@ A list of initial tasks to move the project forward.
 1. Switched to backend TTS streaming audio to the UI for playback.
 1. Added timestamped transcript logging for STT and TTS without console output.
 1. Implemented a macOS `say` TTS backend for streaming speech audio.
+1. Added Orpheus 3B / StyleTTS 2 backend for high-quality speech synthesis.

--- a/src/backend/core/websocket_server.py
+++ b/src/backend/core/websocket_server.py
@@ -17,6 +17,7 @@ from ..agent.simple import EchoAgent
 from ..tts.base import TTS
 from ..tts.simple import ConsoleTTS
 from ..tts.macsay import MacSayTTS
+from ..tts.orpheus import OrpheusStyleTTS
 
 
 class AudioWebSocketServer:
@@ -47,11 +48,17 @@ class AudioWebSocketServer:
         self.tts = tts or self._default_tts()
 
     def _default_tts(self) -> TTS:
-        """Return a TTS instance, preferring ``MacSayTTS`` if available."""
+        """Return a TTS instance, preferring Orpheus if available."""
+        import os
+
+        model_path = os.environ.get("ORPHEUS_MODEL", "orpheus-3b")
         try:
-            return MacSayTTS()
+            return OrpheusStyleTTS(model_path)
         except Exception:
-            return ConsoleTTS()
+            try:
+                return MacSayTTS()
+            except Exception:
+                return ConsoleTTS()
 
     def _timestamp(self) -> str:
         """Return the current timestamp with millisecond precision."""

--- a/src/backend/tts/README.md
+++ b/src/backend/tts/README.md
@@ -1,5 +1,7 @@
 # Text-to-Speech (TTS)
 
-This module will contain wrappers for TTS engines capable of streaming audio playback.
+Wrappers for TTS engines capable of streaming audio playback.
 
-Suggested engines include Piper and Kokoro. Refer to the root README for more details.
+The preferred backend is **Orpheus 3B / StyleTTS 2** for natural-sounding speech.
+Fallback engines include Piper, Kokoro and the macOS `say` command. Refer to the
+root README for installation details.

--- a/src/backend/tts/orpheus.py
+++ b/src/backend/tts/orpheus.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from .base import TTS
+
+
+class OrpheusStyleTTS(TTS):
+    """TTS using the Orpheus 3B / StyleTTS 2 model."""
+
+    def __init__(self, model_path: str, device: str = "cpu") -> None:
+        try:
+            from orpheus_speech import Synthesizer  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("orpheus-speech is required for OrpheusStyleTTS") from exc
+
+        self._synth = Synthesizer(str(Path(model_path)), device=device)
+
+    async def speak(self, text: str) -> bytes:
+        def _run() -> bytes:
+            wav = self._synth.tts(text)
+            if isinstance(wav, bytes):
+                return wav
+            return getattr(wav, "tobytes", lambda: bytes())()
+
+        return await asyncio.to_thread(_run)


### PR DESCRIPTION
## Summary
- add `OrpheusStyleTTS` backend using the `orpheus-speech` package
- prefer Orpheus in WebSocket server with fallback to `say` or a beep
- document installing Orpheus 3B / StyleTTS2
- mention new TTS backend in architecture and todo docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4a8a31c483299bb43e4bd6349b49