### PR TITLE
Add configurable backend and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ git lfs clone https://huggingface.co/orpheus-speech/orpheus-3b-styletts2
 Set the `ORPHEUS_MODEL` environment variable to the path of the cloned
 repository so the backend can find it.
 
+The voice used by Orpheus can be customised in the configuration file via the
+`voice` field under the `tts` section.
+
 A small runner script wires the pieces together using an echo agent and a console
 TTS implementation:
 
@@ -211,14 +214,16 @@ to stdout.
 ### Running the WebSocket server
 
 To stream audio from the React UI, start the WebSocket server. It prints the
-address it is listening on and runs until interrupted. Use `--host` and
-`--port` to change the bind address. Conversation transcripts are written to
-`transcript.log` by default. Use `--transcript-log` to change the file path.
-Each line in the log is timestamped with millisecond precision and prefixed with
-`<` or `>` to indicate STT input or TTS output:
+address it is listening on and runs until interrupted. The server can be
+configured via a JSON file passed with `--config`. Command line options override
+the values in the config. Use `--host` and `--port` to change the bind address.
+Conversation transcripts are written to `transcript.log` by default. Use
+`--transcript-log` to change the file path. Each line in the log is timestamped
+with millisecond precision and prefixed with `<` or `>` to indicate STT input or
+TTS output:
 
 ```bash
-python -m src.backend.core.websocket_server vosk-model
+python -m src.backend.core.websocket_server --config config.example.json
 ```
 
 The server now also feeds final transcripts to the built-in echo agent. Speech

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,19 @@
+{
+  "stt": {
+    "type": "vosk",
+    "model_path": "vosk-model",
+    "samplerate": 16000
+  },
+  "tts": {
+    "type": "orpheus",
+    "model_path": "orpheus-3b",
+    "device": "cpu",
+    "voice": "default"
+  },
+  "agent": { "type": "echo" },
+  "server": {
+    "host": "localhost",
+    "port": 8000,
+    "transcript_log": "transcript.log"
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,3 +64,10 @@ src/
 
 A simple CLI runner located at `src/backend/core/runner.py` wires the default
 components together for testing.
+
+## Configuration
+
+Each backend component (STT, TTS, agent and server) can be configured via a JSON
+file. The WebSocket server loads this configuration at startup and uses the
+settings to instantiate the appropriate classes. Command line arguments override
+values from the file.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -10,8 +10,8 @@ A list of initial tasks to move the project forward.
 1. Create the asynchronous event loop connecting STT, Agent and TTS modules.
 1. Add interruption detection so user speech can cut off TTS playback.
 1. Define a plugin mechanism to swap out the agent with more advanced versions.
-1. Document configuration options and provide example scripts.
-1. Write tests for individual components where possible.
+1. ~~Document configuration options and provide example scripts.~~
+1. ~~Write tests for individual components where possible.~~
 
 # Done
 

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, is_dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class STTConfig:
+    type: str = "vosk"
+    model_path: str = "vosk-model"
+    samplerate: int = 16000
+
+
+@dataclass
+class TTSConfig:
+    type: str = "orpheus"
+    model_path: str = "orpheus-3b"
+    device: str = "cpu"
+    voice: str = "default"
+
+
+@dataclass
+class AgentConfig:
+    type: str = "echo"
+
+
+@dataclass
+class ServerConfig:
+    host: str = "localhost"
+    port: int = 8000
+    transcript_log: Optional[str] = "transcript.log"
+
+
+@dataclass
+class BackendConfig:
+    stt: STTConfig = field(default_factory=STTConfig)
+    tts: TTSConfig = field(default_factory=TTSConfig)
+    agent: AgentConfig = field(default_factory=AgentConfig)
+    server: ServerConfig = field(default_factory=ServerConfig)
+
+
+def _update(obj, data):
+    for key, value in data.items():
+        if hasattr(obj, key):
+            attr = getattr(obj, key)
+            if is_dataclass(attr) and isinstance(value, dict):
+                _update(attr, value)
+            else:
+                setattr(obj, key, value)
+
+
+def load_config(path: str | None) -> BackendConfig:
+    cfg = BackendConfig()
+    if path:
+        data = json.loads(Path(path).read_text())
+        _update(cfg, data)
+    return cfg
+
+
+def create_stt(cfg: STTConfig):
+    if cfg.type == "vosk":
+        from .stt import VoskStream
+        return VoskStream(cfg.model_path, samplerate=cfg.samplerate)
+    raise ValueError(f"Unknown STT type: {cfg.type}")
+
+
+def create_agent(cfg: AgentConfig):
+    if cfg.type == "echo":
+        from .agent.simple import EchoAgent
+        return EchoAgent()
+    raise ValueError(f"Unknown agent type: {cfg.type}")
+
+
+def create_tts(cfg: TTSConfig):
+    if cfg.type == "orpheus":
+        from .tts.orpheus import OrpheusStyleTTS
+        return OrpheusStyleTTS(cfg.model_path, device=cfg.device, voice=cfg.voice)
+    if cfg.type == "macsay":
+        from .tts.macsay import MacSayTTS
+        return MacSayTTS()
+    if cfg.type == "console":
+        from .tts.simple import ConsoleTTS
+        return ConsoleTTS()
+    raise ValueError(f"Unknown TTS type: {cfg.type}")

--- a/src/backend/tts/orpheus.py
+++ b/src/backend/tts/orpheus.py
@@ -9,13 +9,13 @@ from .base import TTS
 class OrpheusStyleTTS(TTS):
     """TTS using the Orpheus 3B / StyleTTS 2 model."""
 
-    def __init__(self, model_path: str, device: str = "cpu") -> None:
+    def __init__(self, model_path: str, device: str = "cpu", voice: str = "default") -> None:
         try:
             from orpheus_speech import Synthesizer  # type: ignore
         except Exception as exc:  # pragma: no cover - optional dependency
             raise RuntimeError("orpheus-speech is required for OrpheusStyleTTS") from exc
 
-        self._synth = Synthesizer(str(Path(model_path)), device=device)
+        self._synth = Synthesizer(str(Path(model_path)), device=device, voice=voice)
 
     async def speak(self, text: str) -> bytes:
         def _run() -> bytes:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,27 @@
+import json
+import pathlib
+import sys
+from unittest import mock
+import types
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from src.backend import config
+
+
+def test_load_config_overrides_defaults(tmp_path):
+    cfg_file = tmp_path / "cfg.json"
+    cfg_file.write_text(json.dumps({"server": {"port": 9000}, "tts": {"voice": "alice"}}))
+    cfg = config.load_config(str(cfg_file))
+    assert cfg.server.port == 9000
+    assert cfg.server.host == "localhost"
+    assert cfg.tts.voice == "alice"
+
+
+def test_create_tts_passes_voice():
+    fake = types.SimpleNamespace(Synthesizer=mock.Mock())
+    with mock.patch.dict(sys.modules, {"orpheus_speech": fake}):
+        cfg = config.TTSConfig(type="orpheus", model_path="m", voice="bob")
+        tts = config.create_tts(cfg)
+        fake.Synthesizer.assert_called_with("m", device="cpu", voice="bob")
+        assert tts is not None


### PR DESCRIPTION
## Summary
- add JSON-based backend configuration module
- allow passing config file to websocket server
- let Orpheus TTS select a voice
- document configuration support and provide example file
- add tests for configuration and update websocket server tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b51f69b448329b784b125e81114e5