### PR TITLE
Add spectrogram and silence threshold control

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This project aims to provide a foundation for building a fully on-device AI voic
 - **Raw PCM streaming:** The UI uses an AudioWorklet to send 16 kHz mono PCM
   bytes to the backend for compatibility with Vosk and other STT engines
 - **Silence detection:** Audio frames are skipped when no speech is detected
+- **Adjustable threshold:** The silence threshold can be tweaked via a slider in
+  the UI and a live spectrogram visualizes microphone input
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,6 +21,8 @@ This document outlines the planned architecture for the real-time voice chat app
    - Captures microphone audio and streams it to the backend STT engine over a WebSocket connection
    - Skips sending audio when input is silent to reduce bandwidth
    - Microphone capture is toggled on/off via a button (no push-to-talk)
+   - A slider controls the silence detection threshold and a live spectrogram
+     shows microphone levels
    - Shows live counts of audio bytes sent and received when listening
    - Receives updates from the agent to modify the UI in real time
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -40,3 +40,4 @@ A list of initial tasks to move the project forward.
 1. Added Orpheus 3B / StyleTTS 2 backend for high-quality speech synthesis.
 1. Added silence detection in the UI to avoid sending empty audio frames.
 1. Included `orpheus-speech` in the dependency manifests.
+1. Added a spectrogram display and slider to adjust the silence threshold.

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -14,3 +14,5 @@ npm run dev
 Open `http://localhost:5173` in your browser to view the app.
 
 The UI streams microphone audio to the backend via a WebSocket connection and displays the conversation history. Start the Python WebSocket server before launching the UI.
+
+A spectrogram visualizes the incoming audio while listening. Use the slider below the conversation history to adjust the silence detection threshold if the default is too aggressive.

--- a/src/ui/src/app.css
+++ b/src/ui/src/app.css
@@ -36,3 +36,14 @@
   padding: 0.5rem 1rem;
   font-size: 1rem;
 }
+
+.controls {
+  margin: 0.5rem 0;
+}
+
+.spectrogram {
+  width: 100%;
+  height: 100px;
+  background: #000;
+  margin-bottom: 0.5rem;
+}

--- a/src/ui/src/pcmWorklet.ts
+++ b/src/ui/src/pcmWorklet.ts
@@ -1,7 +1,16 @@
 class PCMProcessor extends AudioWorkletProcessor {
   private readonly inputSampleRate = sampleRate;
   private readonly outputSampleRate = 16000;
-  private readonly silenceThreshold = 0.002;
+  private silenceThreshold = 0.002;
+
+  constructor() {
+    super();
+    this.port.onmessage = (ev: MessageEvent) => {
+      if (typeof ev.data.silenceThreshold === 'number') {
+        this.silenceThreshold = ev.data.silenceThreshold;
+      }
+    };
+  }
 
   process(inputs: Float32Array[][]) {
     const input = inputs[0][0];


### PR DESCRIPTION
## Summary
- display spectrogram of mic input in UI
- allow users to adjust silence threshold with a slider
- update PCM worklet to receive threshold changes
- document new UI features in README and architecture docs
- note completion in todo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b52d4d0148329bb8d31b2083bb1cd