### PR TITLE
Improve dev runner model download

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This project aims to provide a foundation for building a fully on-device AI voic
 | ---------------- | -------------------------------------------------- | ------------------------------------------ |
 | **Piper (MIT)**  | `brew install portaudio`<br>`git clone https://github.com/rhasspy/piper && make` | Fast, many voices, 24kHz, <1GB             |
 | **Kokoro-82 M**  | `pip install kokoro`                               | Very fast, 82M params, natural sound       |
-| **Orpheus 3B / StyleTTS 2** | `pip install orpheus-speech`<br>`git lfs clone https://huggingface.co/orpheus-speech/orpheus-3b-styletts2` | Diffusion-based, near-human quality |
+| **Orpheus 3B / StyleTTS 2** | `pip install orpheus-speech` (model auto-download) | Diffusion-based, near-human quality |
 | **Mimic 3**      | `pip install mimic3-tts`                           | <1GB RAM, privacy-first, multi-language    |
 | **AVSpeechSynthesizer** | Native API                                  | Built-in voices, offline once downloaded   |
 
@@ -180,25 +180,18 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Next download a Vosk model (50MB) and extract it somewhere on disk:
+The development runner will download the required Vosk and Orpheus models
+automatically after asking for permission. If you prefer manual installation,
+download a Vosk model from <https://alphacephei.com/vosk/models> and fetch the
+Orpheus weights with `curl`:
 
 ```bash
-curl -L -o model.zip https://alphacephei.com/vosk/models/vosk-model-small-en-us-0.15.zip
-unzip model.zip && mv vosk-model-small-en-us-0.15 vosk-model
+curl -L -o orpheus.tar.gz "https://huggingface.co/orpheus-speech/orpheus-3b-styletts2/resolve/main/orpheus.tar.gz"
+mkdir orpheus-3b && tar -xzf orpheus.tar.gz -C orpheus-3b
 ```
 
-### Installing Orpheus 3B / StyleTTS 2
-
-Install the TTS package and download the model weights:
-
-```bash
-pip install orpheus-speech
-git lfs install
-git lfs clone https://huggingface.co/orpheus-speech/orpheus-3b-styletts2
-```
-
-Set the `ORPHEUS_MODEL` environment variable to the path of the cloned
-repository so the backend can find it.
+Set the `ORPHEUS_MODEL` environment variable to the extraction directory if you
+use a custom location. Use `ORPHEUS_REPO` to override the download URL.
 
 The voice used by Orpheus can be customised in the configuration file via the
 `voice` field under the `tts` section.
@@ -242,14 +235,12 @@ It ensures a Python virtual environment exists, installs the dependencies and
 launches both the WebSocket backend and React frontend. If run outside the
 virtual environment it will create it, install the packages and restart itself.
 The script displays the
-latest logs in a Rich dashboard and accepts single-letter commands. Make sure
-the required Vosk and Orpheus models are already installed; the runner will exit
-with instructions if they're missing:
+latest logs in a Rich dashboard and accepts single-letter commands. Missing
+models are downloaded automatically after confirmation:
 
 ```
 Q - quit all processes
 R - restart the backend
-P - git pull and restart
 ```
 
 Run the script from the repository root:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,11 +66,11 @@ src/
 
 A simple CLI runner located at `src/backend/core/runner.py` wires the default
 components together for testing. For development convenience there is also a
-Rich based dashboard runner at `scripts/dev_runner.py` which installs
-dependencies and launches both the backend server and React UI. If started
-outside the virtual environment it creates it, installs the packages and
-restarts itself. It expects the required Vosk and Orpheus models to already be
-downloaded.
+ Rich based dashboard runner at `scripts/dev_runner.py` which installs
+ dependencies and launches both the backend server and React UI. If started
+ outside the virtual environment it creates it, installs the packages and
+ restarts itself. Missing Vosk and Orpheus models are downloaded automatically
+ using only macOS built-in tools after prompting the user.
 
 ## Configuration
 

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -28,9 +28,8 @@ The bottom line of the terminal shows a small prompt accepting single-letter com
 
 - `Q` – quit all running processes and exit.
 - `R` – restart the backend services (relaunch the WebSocket server and refresh the log panes).
-- `P` – perform `git pull` and restart the backend.
 
-The current commit hash and timestamp are displayed right justified on the bottom line.
+The current timestamp is displayed right justified on the bottom line.
 
 ## 4. Implementation Options
 
@@ -63,6 +62,6 @@ The *Rich* library will be used, as neither tmux nor screen are installed by def
    - Pane 2: displays a view of the current config, with colours distinguishing property names from values
    - Pane 3: run the WebSocket streamer backend (e.g. `python -m src.backend.server > backkend.log`) and display a colourised equivalent of `tail -F backend.log`
    - Pane 4: display the output of `npm run dev`
-5. Display the command prompt on the bottom line for `Q`, `R` and `P` actions and the current commit hash and timestamp.
+5. Display the command prompt on the bottom line for `Q` and `R` actions and show the current timestamp.
 
 This plan provides an installer and runner that simplifies setup and offers a convenient console dashboard for development.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -44,3 +44,6 @@ A list of initial tasks to move the project forward.
 1. Added detailed error messages for invalid or unknown config options.
 1. Implemented a Rich based development runner that installs dependencies and
    launches the backend and frontend together.
+1. Added automatic model downloads to the development runner.
+1. Simplified Orpheus download to use curl and tar instead of git.
+1. Removed git dependency from the development runner.


### PR DESCRIPTION
## Summary
- automate model download in `dev_runner`
- update README instructions for automatic downloads
- note automatic downloads in architecture docs
- update docs todo
- use curl/tar for orpheus download
- remove git pull logic from dev runner

## Testing
- `pytest -q`
- `pip list --outdated --format=columns` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_684d86e957488329b997e44cd6bcdfc2