### PR TITLE
Synchronize submodule READMEs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -47,3 +47,4 @@ A list of initial tasks to move the project forward.
 1. Added automatic model downloads to the development runner.
 1. Simplified Orpheus download to use curl and tar instead of git.
 1. Removed git dependency from the development runner.
+1. Checked and updated submodule README files for consistency with the root README.

--- a/src/README.md
+++ b/src/README.md
@@ -1,1 +1,6 @@
 
+# Source Modules
+
+This directory hosts the Python backend and React web UI.
+See the project root `README.md` for build and usage instructions.
+Each subdirectory includes its own README describing the component.

--- a/src/backend/stt/README.md
+++ b/src/backend/stt/README.md
@@ -2,4 +2,6 @@
 
 Utility code and interfaces for integrating local speech recognition engines.
 
-Recommended engines include `whisper.cpp` and `mlx-whisper`. See the project root README for installation tips.
+The WebSocket backend currently uses **Vosk** for low-latency streaming STT.
+Other engines such as `whisper.cpp` and `mlx-whisper` are also supported.
+See the project root README for installation tips and additional options.


### PR DESCRIPTION
## Summary
- note that Vosk is the default STT engine in backend docs
- document purpose of `src` directory
- record completed README sync task in docs/todo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684df1d6371883299d95f9b1a3564114